### PR TITLE
Latest 2.15 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This module deploys a VCN, an Aviatrix spoke gateway, and attaches it to an Avia
 ### Compatibility
 Module version | Terraform version | Controller version | Terraform provider version
 :--- | :--- | :--- | :---
+v4.0.6 | 0.13, 0.14, 0.15 | >=6.4 | 2.19.5
 v4.0.5 | 0.13, 0.14, 0.15 | >=6.4 | 2.19.5
 v4.0.3 | 0.13,0.14 | >=6.4 | >=0.2.19
 v4.0.2 | 0.13,0.14 | >=6.4 | >=0.2.19
@@ -33,7 +34,7 @@ with ha_gw set to false, the following will be deployed:
 # OCI Spoke Module
 module "oci_spoke_1" {
   source         = "terraform-aviatrix-modules/oci-spoke/aviatrix"
-  version        = "4.0.5"
+  version        = "4.0.6"
 
   name           = "my-oci-spoke"
   cidr           = "10.3.0.0/16"
@@ -74,8 +75,17 @@ enable_private_vpc_default_route | false| Program default route in VPC private r
 enable_skip_public_route_table_update| false | Skip programming VPC public route table
 enable_auto_advertise_s2c_cidrs | false | Auto Advertise Spoke Site2Cloud CIDRs
 insane_mode | false | Set to true for insane mode encryption
+attached_gw_egress | true | Set to false if you don't want to attach spoke to transit_gw2
+transit_gw_egress| | Name of the transit gateway to attach this spoke to
+transit_gw_route_tables | [] | Route tables to propagate routes to for transit_gw attachment
+transit_gw_egress_route_tables | [] | Route tables to propagate routes to for transit_gw_egress attachment
+private_vpc_default_route | false | Program default route in VPC private route table
+skip_public_route_table_update | false | Skip programming VPC public route table
+auto_advertise_s2c_cidrs | false | Auto Advertise Spoke Site2Cloud CIDRs
+tunnel_detection_time | | The IPsec tunnel down detection time for the Spoke Gateway in seconds. Must be a number in the range [20-600]
+inspection | false | Set to true to enable east/west Firenet inspection. Only valid when transit_gw is East/West transit Firenet
 
-Outputs
+### Outputs
 This module will return the following objects:
 
 key | description

--- a/main.tf
+++ b/main.tf
@@ -9,27 +9,32 @@ resource "aviatrix_vpc" "default" {
 
 #OCI Spoke Gateway 
 resource "aviatrix_spoke_gateway" "default" {
-  gw_name                           = local.name
-  vpc_id                            = aviatrix_vpc.default.name
-  cloud_type                        = 16
-  vpc_reg                           = var.region
-  enable_active_mesh                = var.active_mesh
-  gw_size                           = var.instance_size
-  account_name                      = var.account
-  subnet                            = local.subnet
-  ha_subnet                         = var.ha_gw ? local.ha_subnet : null
-  ha_gw_size                        = var.ha_gw ? var.instance_size : null
-  manage_transit_gateway_attachment = false
-  single_az_ha                      = var.single_az_ha
-  single_ip_snat                    = var.single_ip_snat
-  customized_spoke_vpc_routes       = var.customized_spoke_vpc_routes
-  filtered_spoke_vpc_routes         = var.filtered_spoke_vpc_routes
-  included_advertised_spoke_routes  = var.included_advertised_spoke_routes
-  insane_mode                       = var.insane_mode
-  availability_domain               = aviatrix_vpc.default.availability_domains[0]
-  fault_domain                      = aviatrix_vpc.default.fault_domains[0]
-  ha_availability_domain            = var.ha_gw ? aviatrix_vpc.default.availability_domains[1] : null
-  ha_fault_domain                   = var.ha_gw ? aviatrix_vpc.default.fault_domains[1] : null
+  gw_name                               = local.name
+  vpc_id                                = aviatrix_vpc.default.name
+  cloud_type                            = 16
+  vpc_reg                               = var.region
+  enable_active_mesh                    = var.active_mesh
+  gw_size                               = var.instance_size
+  account_name                          = var.account
+  subnet                                = local.subnet
+  ha_subnet                             = var.ha_gw ? local.ha_subnet : null
+  ha_gw_size                            = var.ha_gw ? var.instance_size : null
+  manage_transit_gateway_attachment     = false
+  single_az_ha                          = var.single_az_ha
+  single_ip_snat                        = var.single_ip_snat
+  customized_spoke_vpc_routes           = var.customized_spoke_vpc_routes
+  filtered_spoke_vpc_routes             = var.filtered_spoke_vpc_routes
+  included_advertised_spoke_routes      = var.included_advertised_spoke_routes
+  insane_mode                           = var.insane_mode
+  availability_domain                   = aviatrix_vpc.default.availability_domains[0]
+  fault_domain                          = aviatrix_vpc.default.fault_domains[0]
+  ha_availability_domain                = var.ha_gw ? aviatrix_vpc.default.availability_domains[1] : null
+  ha_fault_domain                       = var.ha_gw ? aviatrix_vpc.default.fault_domains[1] : null
+  enable_private_vpc_default_route      = var.private_vpc_default_route
+  enable_skip_public_route_table_update = var.skip_public_route_table_update
+  enable_auto_advertise_s2c_cidrs       = var.auto_advertise_s2c_cidrs
+  tunnel_detection_time                 = var.tunnel_detection_time
+
 }
 
 resource "aviatrix_spoke_transit_attachment" "default" {
@@ -38,10 +43,24 @@ resource "aviatrix_spoke_transit_attachment" "default" {
   transit_gw_name = var.transit_gw
 }
 
+resource "aviatrix_spoke_transit_attachment" "transit_gw_egress" {
+  count           = length(var.transit_gw_egress) > 0 ? (var.attached_gw_egress ? 1 : 0) : 0
+  spoke_gw_name   = aviatrix_spoke_gateway.default.gw_name
+  transit_gw_name = var.transit_gw_egress
+  route_tables    = var.transit_gw_egress_route_tables
+}
+
 resource "aviatrix_segmentation_security_domain_association" "default" {
   count                = var.attached ? (length(var.security_domain) > 0 ? 1 : 0) : 0 #Only create resource when attached and security_domain is set.
   transit_gateway_name = var.transit_gw
   security_domain_name = var.security_domain
   attachment_name      = aviatrix_spoke_gateway.default.gw_name
   depends_on           = [aviatrix_spoke_transit_attachment.default] #Let's make sure this cannot create a race condition
+}
+
+resource "aviatrix_transit_firenet_policy" "default" {
+  count                        = var.inspection ? (var.attached ? 1 : 0) : 0
+  transit_firenet_gateway_name = var.transit_gw
+  inspected_resource_name      = "SPOKE:${aviatrix_spoke_gateway.default.gw_name}"
+  depends_on                   = [aviatrix_spoke_transit_attachment.default] #Let's make sure this cannot create a race condition
 }

--- a/variables.tf
+++ b/variables.tf
@@ -120,6 +120,60 @@ variable "enable_auto_advertise_s2c_cidrs" {
   default     = false
 }
 
+variable "attached_gw_egress" {
+  description = "Set to false if you don't want to attach spoke to transit_gw2."
+  type        = bool
+  default     = true
+}
+
+variable "transit_gw_egress" {
+  description = "Name of the transit gateway to attach this spoke to"
+  type        = string
+  default     = ""
+}
+
+variable "transit_gw_route_tables" {
+  description = "Route tables to propagate routes to for transit_gw attachment"
+  type        = list(string)
+  default     = []
+}
+
+variable "transit_gw_egress_route_tables" {
+  description = "Route tables to propagate routes to for transit_gw_egress attachment"
+  type        = list(string)
+  default     = []
+}
+
+variable "private_vpc_default_route" {
+  description = "Program default route in VPC private route table."
+  type        = bool
+  default     = false
+}
+
+variable "skip_public_route_table_update" {
+  description = "Skip programming VPC public route table."
+  type        = bool
+  default     = false
+}
+
+variable "auto_advertise_s2c_cidrs" {
+  description = "Auto Advertise Spoke Site2Cloud CIDRs."
+  type        = bool
+  default     = false
+}
+
+variable "tunnel_detection_time" {
+  description = "The IPsec tunnel down detection time for the Spoke Gateway in seconds. Must be a number in the range [20-600]."
+  type        = number
+  default     = null
+}
+
+variable "inspection" {
+  description = "Set to true to enable east/west Firenet inspection. Only valid when transit_gw is East/West transit Firenet"
+  type        = bool
+  default     = false
+}
+
 locals {
   lower_name = replace(lower(var.name), " ", "-")
   prefix     = var.prefix ? "avx-" : ""


### PR DESCRIPTION
**Updates for the following variables**
- attached_gw_egress 
- transit_gw_egress|
- transit_gw_route_tables 
- transit_gw_egress_route_tables
- private_vpc_default_route 
- skip_public_route_table_update 
- auto_advertise_s2c_cidrs
- tunnel_detection_time 
- inspection

**Updates for logic to allow**
- dual mode (attaching to ew and egress transit gws)
- providing inspection automatically for spoke in transit firenet deployment
- defaulting AD/FD placement based on indexed values from aviatrix_vpc resource